### PR TITLE
Implemented search functionality to get Repository by full name

### DIFF
--- a/src/routes/repositories.router.ts
+++ b/src/routes/repositories.router.ts
@@ -22,6 +22,13 @@ export const CreateRepositoryRouter = (
     }
   })
 
+  // TODO: Complete route implementation.
+  repositoriesRouter.get('/search', (req: Request, res: Response) => {
+    const nameParam = req.query.full_name as string | undefined
+
+    res.status(200).json({ msg: nameParam })
+  })
+
   repositoriesRouter.get('/:id', async (req: Request, res: Response) => {
     const idParam = req.params.id
 

--- a/src/routes/repositories.router.ts
+++ b/src/routes/repositories.router.ts
@@ -27,7 +27,7 @@ export const CreateRepositoryRouter = (
     const nameParam = req.query.full_name as string | undefined
 
     if (!nameParam) {
-      res.status(400).send({ error: 'Invalid or missing repository name.' })
+      res.status(400).send({ error: 'Invalid or missing repository name' })
       return
     }
 

--- a/src/routes/repositories.router.ts
+++ b/src/routes/repositories.router.ts
@@ -22,7 +22,6 @@ export const CreateRepositoryRouter = (
     }
   })
 
-  // TODO: Test route.
   repositoriesRouter.get('/search', async (req: Request, res: Response) => {
     const nameParam = req.query.full_name as string | undefined
 

--- a/src/routes/repositories.router.ts
+++ b/src/routes/repositories.router.ts
@@ -22,11 +22,31 @@ export const CreateRepositoryRouter = (
     }
   })
 
-  // TODO: Complete route implementation.
-  repositoriesRouter.get('/search', (req: Request, res: Response) => {
+  // TODO: Test route.
+  repositoriesRouter.get('/search', async (req: Request, res: Response) => {
     const nameParam = req.query.full_name as string | undefined
 
-    res.status(200).json({ msg: nameParam })
+    if (!nameParam) {
+      res.status(400).send({ error: 'Invalid or missing repository name.' })
+      return
+    }
+
+    try {
+      const repo = await repositoriesService.getRepositoryByFullName(nameParam)
+
+      if (!repo) {
+        res
+          .status(404)
+          .send({ error: `No resource for given name: ${nameParam}` })
+        return
+      }
+
+      res.status(200).json({ repo })
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Error fetching repository'
+      res.status(500).send({ error: message })
+    }
   })
 
   repositoriesRouter.get('/:id', async (req: Request, res: Response) => {

--- a/src/services/repository.service.ts
+++ b/src/services/repository.service.ts
@@ -8,6 +8,7 @@ export class RepositoryService {
     this.repositoryCollection = collections
   }
 
+  // TODO: Add unit tests for these methods.
   /**
    * Returns a list of Repositories.
    *
@@ -32,6 +33,26 @@ export class RepositoryService {
     try {
       const repository = await this.repositoryCollection.findOne({
         gh_id: id
+      })
+
+      return repository
+    } catch (err) {
+      throw new Error('Error fetching repositories')
+    }
+  }
+
+  /**
+   * Returns a single Repository or null if no repository exists with the provided repository name.
+   *
+   * @param repositoryName
+   * @returns Promise
+   */
+  async getRepositoryByFullName(
+    repositoryName: string
+  ): Promise<WithId<Repository> | null> {
+    try {
+      const repository = await this.repositoryCollection.findOne({
+        full_name: repositoryName
       })
 
       return repository

--- a/tests/routes/repositories.test.ts
+++ b/tests/routes/repositories.test.ts
@@ -64,7 +64,8 @@ const NO_RESOURCE_FOR_PROVIDED_ID_ERROR = new Error(
 // TODO: Make a helper function simplify service creation.
 const MOCK_REPOSITORY_SERVICE = {
   getRepositories: mock().mockResolvedValue(MOCK_REPO_LIST),
-  getRepositoryById: mock().mockResolvedValue(MOCK_REPO_ONE)
+  getRepositoryById: mock().mockResolvedValue(MOCK_REPO_ONE),
+  getRepositoryByFullName: mock().mockResolvedValue(MOCK_REPO_TWO)
 } as unknown as RepositoryService
 
 const MOCK_REPOSITORY_SERVICE_NO_REPO_ID = {
@@ -73,7 +74,8 @@ const MOCK_REPOSITORY_SERVICE_NO_REPO_ID = {
 
 const MOCK_REPOSITORY_SERVICE_WITH_ERRORS = {
   getRepositories: () => Promise.reject(GET_REPOSITORIES_ERROR),
-  getRepositoryById: () => Promise.reject(GET_REPOSITORIES_ERROR)
+  getRepositoryById: () => Promise.reject(GET_REPOSITORIES_ERROR),
+  getRepositoryByFullName: () => Promise.reject(GET_REPOSITORIES_ERROR)
 } as unknown as RepositoryService
 
 describe('Routes test suite: ', () => {
@@ -101,6 +103,15 @@ describe('Routes test suite: ', () => {
           .expect(200)
 
         expect(res.body).toEqual({ repo: MOCK_REPO_ONE })
+      })
+
+      test('TEST HERE', async () => {
+        const res = await request(server)
+          .get('/api/v1/repos/search?full_name=user/Test-Repo-Two')
+          .set('Authorization', 'Bearer test-secret')
+          .expect(200)
+
+        expect(res.body).toEqual({ repo: MOCK_REPO_TWO })
       })
     })
 


### PR DESCRIPTION
# Additions
- Added `getByFullName` method to the `RepositoryService` class
- Added the `/search` endpoint 
- Unit tests